### PR TITLE
Use finch for sketching instead of mash

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -76,6 +76,17 @@ Finds the jaccard distance between pairs of kmer profiles in a group of samples.
 
 Runs only on reads that did not align to the human genome or macrobial genomes.
 
+
+Finch Sketch
+------------
+
+Alternative implementation of Mash that includes error-correction for FASTQ files.
+
+`Finch Paper <http://joss.theoj.org/papers/10.21105/joss.00505>`_
+
+`Finch GitHub <https://github.com/onecodex/finch-rs>`_
+
+
 Functional Profiling
 ====================
 

--- a/pipeline_config.py
+++ b/pipeline_config.py
@@ -117,7 +117,9 @@ config = {
         'exc': {
             'filepath': which('finch'),
             'version': resolveCmd('finch --version')
-        }
+        },
+        'seed': 42,
+        'n_hashes': 10000000,
     },
     'humann2_functional_profiling': {
         'exc': {

--- a/pipeline_config.py
+++ b/pipeline_config.py
@@ -113,6 +113,12 @@ config = {
             'version': resolveCmd('mash --version')
         }
     },
+    'finch': {
+        'exc': {
+            'filepath': which('finch'),
+            'version': resolveCmd('finch --version')
+        }
+    },
     'humann2_functional_profiling': {
         'exc': {
             'filepath': which('humann2'),

--- a/pipeline_definition.json
+++ b/pipeline_definition.json
@@ -131,11 +131,11 @@
       }
     },
     {
-	  "NAME": "mash_sketch",
-	  "DEPENDENCIES": ["microbial_short_read_dna"],
-	  "FILES": {
-	      "sketch": "minsketch"
-	    }
+      "NAME": "finch_sketch",
+      "DEPENDENCIES": ["microbial_short_read_dna"],
+      "FILES": {
+        "sketch": "minsketch"
+      }
     },
     {
       "NAME": "read_classification_proportions",

--- a/snakemake_files/finch_sketch.smk
+++ b/snakemake_files/finch_sketch.smk
@@ -8,10 +8,12 @@ rule finch_sketch:
     threads: 1
     params:
         exc=config['finch']['exc']['filepath'],
+        seed=config['finch']['hash_seed'],
+        n_hashes=config['finch']['n_hashes'],
     resources:
         time = 1,
         n_gb_ram = 10
     run:
-        cmd = '{params.exc} sketch --no-strict --seed 42 --n-hashes 10000000 --binary-format -o {output.sketch} {input.reads1}'
+        cmd = '{params.exc} sketch --no-strict --seed {params.seed} --n-hashes {params.n_hashes} --binary-format -o {output.sketch} {input.reads1}'
         shell(cmd)
 

--- a/snakemake_files/finch_sketch.smk
+++ b/snakemake_files/finch_sketch.smk
@@ -1,0 +1,17 @@
+
+
+rule finch_sketch:
+    input:
+        reads1 = config['filter_human_dna']['nonhuman_read1']
+    output:
+        sketch = config['mash_sketch']['sketch'],
+    threads: 1
+    params:
+        exc=config['finch']['exc']['filepath'],
+    resources:
+        time = 1,
+        n_gb_ram = 10
+    run:
+        cmd = '{params.exc} sketch --no-strict --seed 42 --n-hashes 10000000 --binary-format -o {output.sketch} {input.reads1}'
+        shell(cmd)
+

--- a/snakemake_files/stats/diversity/mash_intersample_dists.smk
+++ b/snakemake_files/stats/diversity/mash_intersample_dists.smk
@@ -8,7 +8,7 @@ kraken_taxonomy_profiling.snkmk
 
 rule mash_dists:
     input:
-        sketch = expandGroup(config['mash_sketch']['sketch'])
+        sketch = expandGroup(config['finch_sketch']['sketch'])
     output:
         distTable=config['mash_intersample_dists']['distance_table']
     resources:

--- a/snakemake_files/stats/hmp_site_dists.smk
+++ b/snakemake_files/stats/hmp_site_dists.smk
@@ -35,7 +35,7 @@ rule measure_hmp_dists_kraken:
 
 rule measure_hmp_dists_mash:
 	input:
-            sketch = config['mash_sketch']['sketch'],
+            sketch = config['finch_sketch']['sketch'],
             db=config['pipeline_dir'] + '/references/hmp_site_dists/hmp_sites.msh'
 	output:
 	    main=config['hmp_site_dists']['mash']


### PR DESCRIPTION
In addition to a slight speed bump, Finch has some extra quality filtering (specifically for adapters and errors) that helps when handling raw FASTQ data. Note that this still uses mash for downstream distance calculations.

I'm not exactly sure the project format here, so please let me know if there's anything in this PR that needs to be changed or if more needs to added to get everything to run.

Thanks!
Roderick